### PR TITLE
fix:logout stack issue

### DIFF
--- a/app/src/main/java/com/example/mobiledev/data/repository/FirebaseUserRepository.kt
+++ b/app/src/main/java/com/example/mobiledev/data/repository/FirebaseUserRepository.kt
@@ -5,7 +5,9 @@ import com.example.mobiledev.data.model.User
 import com.google.firebase.FirebaseApp
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.FirebaseDatabase
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import org.mindrot.jbcrypt.BCrypt
 
 class FirebaseUserRepository(
@@ -22,9 +24,9 @@ class FirebaseUserRepository(
 
     private val usersRef by lazy { db.getReference(USERS_NODE) }
 
-    override suspend fun getUsers(): List<User> {
+    override suspend fun getUsers(): List<User> = withContext(Dispatchers.Default) {
         val snapshot = usersRef.get().await()
-        return snapshot.children.mapNotNull { child ->
+        snapshot.children.mapNotNull { child ->
             child.toUserOrNull()
         }
     }

--- a/app/src/main/java/com/example/mobiledev/data/repository/FirebaseUserRepository.kt
+++ b/app/src/main/java/com/example/mobiledev/data/repository/FirebaseUserRepository.kt
@@ -24,7 +24,7 @@ class FirebaseUserRepository(
 
     private val usersRef by lazy { db.getReference(USERS_NODE) }
 
-    override suspend fun getUsers(): List<User> = withContext(Dispatchers.Default) {
+    override suspend fun getUsers(): List<User> = withContext(Dispatchers.IO) {
         val snapshot = usersRef.get().await()
         snapshot.children.mapNotNull { child ->
             child.toUserOrNull()

--- a/app/src/main/java/com/example/mobiledev/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/mobiledev/navigation/NavGraph.kt
@@ -94,14 +94,14 @@ fun NavGraph(
         ApiStaffRepository(retrofit.create(StaffApiService::class.java))
     }
 
-    // Handle logout or session expiration globally without triggering global recomposition
+    // Handle logout or session expiration globally
     LaunchedEffect(Unit) {
         authSessionManager.principal.collect { principal ->
             if (principal.role == AppRole.GUEST) {
                 val currentRoute = navController.currentDestination?.route
                 if (currentRoute != Screen.SignIn.route && currentRoute != Screen.SignUp.route) {
                     navController.navigate(Screen.SignIn.route) {
-                        popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                        popUpTo(0) { inclusive = true }
                         launchSingleTop = true
                     }
                 }
@@ -283,6 +283,11 @@ fun NavGraph(
         }
 
         composable(Screen.HospitalDashboard.route) { backStackEntry ->
+            val principal by authSessionManager.principal.collectAsState()
+            if (principal.role == AppRole.GUEST) {
+                return@composable
+            }
+
             val hospitalId = backStackEntry.arguments?.getString("hospitalId") ?: ""
             if (hospitalId.isBlank()) {
                 Text("Invalid hospital session. Please sign in again.")


### PR DESCRIPTION
## Summary by Sourcery

Handle guest logout navigation more robustly and improve Firebase user retrieval concurrency behavior.

Bug Fixes:
- Ensure logout navigation clears the entire back stack to prevent returning to authenticated screens after session expiration.
- Prevent guest users from accessing the hospital dashboard composable when the session has expired.

Enhancements:
- Wrap Firebase user retrieval in a background dispatcher to avoid blocking the main thread during snapshot processing.